### PR TITLE
Fix wrong plots in Traditional Ensemble Murder

### DIFF
--- a/data/midnight-circle/scripts.jsonc
+++ b/data/midnight-circle/scripts.jsonc
@@ -78,11 +78,11 @@
             ],
             "tragedySet": "basicTragedy",
             "mainPlot": [
-                "changeOfFuture"
+                "murderPlan"
             ],
             "subPlots": [
-                "loveAffair",
-                "circleFriends"
+                "unsettlingRumor",
+                "hiddenFreak"
             ],
             "difficultySets": [
                 {


### PR DESCRIPTION
As you can see, the website currently states "Change of Future" even though there is no Time Traveler.